### PR TITLE
Update JobDetailsPage to fetch job data from Firebase

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,9 +43,9 @@ function App() {
           <Route path="/job-listing" element={<JobListingPage />} />
           <Route path="/about-us" element={<AboutUsPage />} />
           <Route path="/404" element={<Page404 />} />
-          <Route path="*" element={<Page404 />} />
           <Route path="/job-listing/:id" element={<JobDetailsPage />} />
           <Route path="/post-job" element={<PostJobPage />} />
+          <Route path="*" element={<Page404 />} />
         </Routes>
       </Layout>
     </Router>

--- a/src/pages/NoJobFound.jsx
+++ b/src/pages/NoJobFound.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import Error404 from '../assets/vecteezy404Error.jpg';
 import next from '../assets/next.png';
 
-const Page404 = () => {
+const NoJobFound = () => {
   return (
     <section className="bg-white py-[120px]">
       <div className="wrapper flex xl:flex-row flex-col items-center justify-between">
@@ -14,11 +14,14 @@ const Page404 = () => {
         />
         <div className="w-fit xl:w-[39%] flex flex-col space-y-12 text-center xl:text-left">
           <h1 className="flex flex-col capitalize text-[100px] leading-tight text-[#31795A]">
-            404 <span className="text-black text-[82px] "> page not found</span>
+            404 <span className="text-black text-[82px] ">Oh-no...</span>
           </h1>
-          <p className="text-2xl">
-            These aren't the droids you're looking for... I mean pages...
+          <p className="text-2xl ">
+            No job listing found... Maybe the job post was deleted, or you
+            copypasta the wrong link?
           </p>
+          <p className="text-8xl mx-auto">🍝</p>
+          <p className="text-xl mx-auto">Mmm... pasta...</p>
           <Link
             role="button"
             aria-label="Go back to job listing"
@@ -34,4 +37,4 @@ const Page404 = () => {
   );
 };
 
-export default Page404;
+export default NoJobFound;


### PR DESCRIPTION
- Use useParams hook to access Firebase ID from URL
- Add fetchJob function to fetch job data from Firebase using Firebase ID
- Update JobDetailsPage component to fetch job data from Firebase if not available in location state
- Add missing import for getDoc function from firebase/firestore
- Add NoJobFound component that acts like a 404 for job listings if endpoint param for job ID from database is incorrect

The purpose of this commit was to solve the issue of being able to share url and not lead to an empty page or 404