### PR TITLE
JobCategory screen width fix

### DIFF
--- a/src/pages/Home/JobCategory.jsx
+++ b/src/pages/Home/JobCategory.jsx
@@ -12,7 +12,7 @@ import iconAccounting from '../../assets/iconAccounting.png';
 
 const JobCategory = () => {
   return (
-    <section className="w-screen h-fit py-36 bg-[#F2F9D8] relative overflow-hidden">
+    <section className="h-fit py-36 bg-[#F2F9D8] relative overflow-hidden">
       {/* Section Screen Wrapper */}
       <div className="wrapper">
         {/* Section Title and Right Side Text Container */}


### PR DESCRIPTION
- Remove width 100% view width styling on section tag on JobCategory section to fix issue with the section creating overflow for all other sections on the home page. 